### PR TITLE
fix NPE on close

### DIFF
--- a/src/main/java/com/github/microwww/redis/RedisServer.java
+++ b/src/main/java/com/github/microwww/redis/RedisServer.java
@@ -36,6 +36,7 @@ public class RedisServer implements Closeable {
 
     public RedisServer(ExecutorService pool) {
         this.pool = pool;
+        this.schema = new Schema(Schema.DEFAULT_SCHEMA_SIZE);
     }
 
     public void configScheme(int size, AbstractOperation... operation) {

--- a/src/test/java/com/github/microwww/DatabaseTest.java
+++ b/src/test/java/com/github/microwww/DatabaseTest.java
@@ -1,11 +1,13 @@
 package com.github.microwww;
 
+import com.github.microwww.redis.RedisServer;
 import org.junit.Assert;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisDataException;
 
+import java.io.IOException;
 import java.util.List;
 
 public class DatabaseTest extends AbstractRedisTest {
@@ -49,5 +51,12 @@ public class DatabaseTest extends AbstractRedisTest {
         jd.auth("123456");
         String result = jd.ping();
         String ss = jd.get("---");
+    }
+
+    @Test
+    public void testConnectDisconnect() throws IOException {
+        RedisServer server = new RedisServer();
+        server.listener("127.0.0.1", 46379);
+        server.close();
     }
 }


### PR DESCRIPTION
While playing with redis-mock example code from readme, I've found that RedisServer throws NPE on `close()` call when schema is not set.

To reproduce:
```java
    RedisServer server = new RedisServer();
    server.listener("127.0.0.1", 6379); // Redis runs in the background
    server.close();
```

which makes a loud blast:
```
java.lang.NullPointerException was thrown.
java.lang.NullPointerException
	at com.github.microwww.redis.RedisServer.close(RedisServer.java:132)
```

Although this code is not triggering the NPE:
```java
    RedisServer server = new RedisServer();
    server.listener("127.0.0.1", 6379); // Redis runs in the background
    server.getSchema(); // MAGIC!
    server.close();
```

Looks like that schema is null by default when nobody set something custom with `setSchema`. In this PR we init the `schema` variable with the default value, as magical `getSchema` does. There is also a reproducer test added in the test suite.