### PR TITLE
fix: fix SCAN MATCH filter and add WrongTypeException

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pure Java implementation redis-server. Embedded redis service when unit testing.
 <dependency>
     <groupId>com.github.microwww</groupId>
     <artifactId>redis-server</artifactId>
-    <version>0.3.5</version>
+    <version>0.3.6</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -50,7 +50,7 @@ A better option is to add dependencies:
 <dependency>
     <groupId>com.github.microwww</groupId>
     <artifactId>mocker-redis-spring-boot-starter</artifactId>
-    <version>5.3.3</version>
+    <version>5.3.6</version>
 </dependency>
 ```
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@
 
     <groupId>com.github.microwww</groupId>
     <artifactId>redis-server</artifactId>
-    <version>0.3.5</version>
+    <version>0.3.6</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/core/src/main/java/com/github/microwww/redis/ChannelContext.java
+++ b/core/src/main/java/com/github/microwww/redis/ChannelContext.java
@@ -29,7 +29,7 @@ public class ChannelContext {
     private final CloseObservable listeners = new CloseObservable();
 
     /**
-     * channel.close 可能无法获取关闭事件, 从而导致 ChannelContext 无法正确的回收 切忌!切忌!切忌!
+     * channel.close may not receive close event, causing ChannelContext to not be properly recycled. IMPORTANT!
      * <br />
      * invoke Channel.close will make some out of memory, so not any one can get it.
      */
@@ -88,7 +88,8 @@ public class ChannelContext {
         if (read < 0) {
             throw new IOException("EOF");
         }
-        buffer.flip();
+        // Use Buffer.flip() for Java 8 compatibility
+        ((java.nio.Buffer) buffer).flip();
         return buffer.asReadOnlyBuffer();
     }
 
@@ -159,7 +160,7 @@ public class ChannelContext {
         Run.ignoreException(log, () -> {
             subscribe.removeSubscribe();
             Map<Bytes, Observer> subscribes = subscribe.subscribes();
-            if (subscribes != null) subscribes.clear(); // 多次 close 可能 NullPointerException
+            if (subscribes != null) subscribes.clear(); // Multiple close may cause NullPointerException
         });
         this.sessions.close();
     }

--- a/core/src/main/java/com/github/microwww/redis/ChannelOutputStream.java
+++ b/core/src/main/java/com/github/microwww/redis/ChannelOutputStream.java
@@ -31,7 +31,8 @@ public class ChannelOutputStream extends OutputStream {
 
     @Override
     public void flush() throws IOException {
-        buffer.flip();
+        // Use Buffer.flip() for Java 8 compatibility
+        ((java.nio.Buffer) buffer).flip();
         channel.write(buffer);
         Assert.isTrue(!buffer.hasRemaining(), "Buffer not write ALL");
         buffer.clear();

--- a/core/src/main/java/com/github/microwww/redis/RedisServer.java
+++ b/core/src/main/java/com/github/microwww/redis/RedisServer.java
@@ -94,7 +94,7 @@ public class RedisServer implements Closeable {
                     RedisMessage redisMessage = Type.parseOne(buffer);
                     this.readableHandler(context, redisMessage);
                 } catch (HalfPackException ex) {
-                    buffer.position(start);
+                    ((java.nio.Buffer) buffer).position(start);
                     break;
                 }
             }

--- a/core/src/main/java/com/github/microwww/redis/database/RedisDatabase.java
+++ b/core/src/main/java/com/github/microwww/redis/database/RedisDatabase.java
@@ -1,5 +1,6 @@
 package com.github.microwww.redis.database;
 
+import com.github.microwww.redis.exception.WrongTypeException;
 import com.github.microwww.redis.util.Assert;
 
 import java.io.Closeable;
@@ -35,8 +36,25 @@ public class RedisDatabase implements DataLock, Closeable {
         return this.get(key, ByteData.class);
     }
 
+    /**
+     * Gets the value of the specified type. Returns Optional.empty() if the key does not exist,
+     * throws WrongTypeException if the key exists but the type does not match.
+     *
+     * @param key the key to look up
+     * @param clazz the expected type
+     * @return Optional wrapping the value
+     * @throws WrongTypeException if the key exists but the type does not match
+     */
     public <U, T extends AbstractValueData<U>> Optional<T> get(HashKey key, Class<T> clazz) {
-        return this.get(key).map(e -> (T) e);
+        Optional<AbstractValueData<?>> opt = this.get(key);
+        if (!opt.isPresent()) {
+            return Optional.empty();
+        }
+        AbstractValueData<?> data = opt.get();
+        if (!clazz.isInstance(data)) {
+            throw new WrongTypeException();
+        }
+        return Optional.of((T) data);
     }
 
     public synchronized <U, T extends AbstractValueData<U>> T getOrCreate(HashKey key, Supplier<T> fun) {

--- a/core/src/main/java/com/github/microwww/redis/database/Schema.java
+++ b/core/src/main/java/com/github/microwww/redis/database/Schema.java
@@ -1,5 +1,6 @@
 package com.github.microwww.redis.database;
 
+import com.github.microwww.redis.exception.WrongTypeException;
 import com.github.microwww.redis.logger.LogFactory;
 import com.github.microwww.redis.logger.Logger;
 import com.github.microwww.redis.protocal.AbstractOperation;
@@ -123,6 +124,9 @@ public class Schema implements Closeable {
         String cmd = request.getCommand();
         try {
             this.execute(cmd, request);
+        } catch (WrongTypeException e) {
+            // Return Redis standard WRONGTYPE error
+            request.getOutputProtocol().writerError(RedisOutputProtocol.Level.ERR, e.getMessage());
         } catch (RedisArgumentsException error) {
             request.getOutputProtocol().writerError(RedisOutputProtocol.Level.ERR, error.getMessage());
         } catch (RuntimeException e) {

--- a/core/src/main/java/com/github/microwww/redis/exception/WrongTypeException.java
+++ b/core/src/main/java/com/github/microwww/redis/exception/WrongTypeException.java
@@ -1,0 +1,23 @@
+package com.github.microwww.redis.exception;
+
+/**
+ * Thrown when an operation is performed on a key holding the wrong data type.
+ * For example: executing GET command on a SortedSet key.
+ *
+ * Redis standard error message:
+ * WRONGTYPE Operation against a key holding the wrong kind of value
+ */
+public class WrongTypeException extends RuntimeException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public static final String MESSAGE = "WRONGTYPE Operation against a key holding the wrong kind of value";
+    
+    public WrongTypeException() {
+        super(MESSAGE);
+    }
+    
+    public WrongTypeException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/github/microwww/redis/protocal/ScanIterator.java
+++ b/core/src/main/java/com/github/microwww/redis/protocal/ScanIterator.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 public class ScanIterator<T> {
 
@@ -41,12 +42,19 @@ public class ScanIterator<T> {
 
     public void continueWrite(Iterator<T> iterator, Function<T, byte[]>... parses) throws IOException {
         int i = this.cursor;
+        Pattern pattern = spm.getPattern();
 
         List<byte[]> list = new ArrayList<>();
-        for (int j = 0; j < spm.getCount() && iterator.hasNext(); j++) {
+        while (iterator.hasNext() && list.size() < spm.getCount()) {
             T next = iterator.next();
-            for (Function<T, byte[]> parse : parses) {
-                list.add(parse.apply(next));
+            // Use the first parse function to get the byte array for matching
+            byte[] bytes = parses[0].apply(next);
+            String keyStr = new String(bytes);
+            // Apply MATCH pattern filter
+            if (pattern.matcher(keyStr).matches()) {
+                for (Function<T, byte[]> parse : parses) {
+                    list.add(parse.apply(next));
+                }
             }
             i++;
         }

--- a/core/src/main/java/com/github/microwww/redis/protocal/message/Type.java
+++ b/core/src/main/java/com/github/microwww/redis/protocal/message/Type.java
@@ -245,7 +245,7 @@ public enum Type {
 
         int pt = bytes.position();
         byte[] data = getData(bytes, pt, pt + length);
-        bytes.position(pt + length);
+        ((java.nio.Buffer) bytes).position(pt + length);
 
         Assert.isTrue(CR == bytes.get(), "end with CR LF");
         Assert.isTrue(LF == bytes.get(), "end with CR LF");

--- a/core/src/test/java/com/github/microwww/redis/protocal/operation/KeyOperationTest.java
+++ b/core/src/test/java/com/github/microwww/redis/protocal/operation/KeyOperationTest.java
@@ -4,6 +4,7 @@ import com.github.microwww.AbstractRedisTest;
 import org.junit.Test;
 import redis.clients.jedis.resps.ScanResult;
 import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.params.SetParams;
 
 import java.util.List;
@@ -30,7 +31,7 @@ public class KeyOperationTest extends AbstractRedisTest {
         jedis.set(key1, key1);
         String key2 = UUID.randomUUID().toString();
         jedis.set(key2, key2);
-        // 异步删除 服务器端使用同步删除
+        // Async delete, server uses synchronous delete
         Long count = jedis.unlink(key1, key2, UUID.randomUUID().toString());
         assertEquals(2, count.longValue());
     }
@@ -288,6 +289,7 @@ public class KeyOperationTest extends AbstractRedisTest {
     public void testScan() {
         String[] r = Server.random(25);
         jedis.select(7);
+        jedis.flushDB(); // Clear database to avoid interference from other tests
         for (int i = 0; i < r.length; i++) {
             jedis.set(r[i], i + "", new SetParams().nx().ex(10L));
         }
@@ -302,5 +304,37 @@ public class KeyOperationTest extends AbstractRedisTest {
             }
         }
         assertEquals(25, size);
+    }
+
+    /**
+     * Test SCAN command MATCH parameter filtering functionality
+     */
+    @Test
+    public void testScanWithMatch() {
+        jedis.select(7);
+        jedis.flushDB();
+        
+        // Create multiple keys with different prefixes
+        jedis.set("user:profile:001", "value1");
+        jedis.set("user:profile:002", "value2");
+        jedis.set("user:settings", "value3");
+        jedis.set("user:session:001", "value4");
+        jedis.set("product:item:001", "value5");
+        
+        // Use MATCH to filter
+        ScanParams params = new ScanParams();
+        params.match("user:profile:*");
+        
+        ScanResult<String> result = jedis.scan("0", params);
+        
+        // Only keys matching user:profile:* should be returned
+        for (String key : result.getResult()) {
+            assertTrue("Key should match pattern user:profile:*",
+                key.startsWith("user:profile:"));
+        }
+        
+        // user:settings should not be returned
+        assertFalse("user:settings should not be in results",
+            result.getResult().contains("user:settings"));
     }
 }

--- a/core/src/test/java/com/github/microwww/redis/protocal/operation/StringOperationTest.java
+++ b/core/src/test/java/com/github/microwww/redis/protocal/operation/StringOperationTest.java
@@ -347,4 +347,58 @@ public class StringOperationTest extends AbstractRedisTest {
             assertEquals(v.length(), nx);
         }
     }
+
+    /**
+     * Test that GET command returns WRONGTYPE error when executed on a non-String type key
+     */
+    @Test
+    public void testGetOnWrongType() {
+        String key = UUID.randomUUID().toString();
+        // First set a SortedSet type key
+        jedis.zadd(key, 1.0, "member1");
+        // Try to read with GET command, should return WRONGTYPE error
+        try {
+            jedis.get(key);
+            fail("Should throw JedisDataException for WRONGTYPE");
+        } catch (redis.clients.jedis.exceptions.JedisDataException e) {
+            assertTrue("Error message should contain WRONGTYPE",
+                e.getMessage().contains("WRONGTYPE"));
+        }
+    }
+
+    /**
+     * Test that STRLEN command returns WRONGTYPE error when executed on a non-String type key
+     */
+    @Test
+    public void testStrlenOnWrongType() {
+        String key = UUID.randomUUID().toString();
+        // First set a List type key
+        jedis.lpush(key, "item1");
+        // Try to read with STRLEN command, should return WRONGTYPE error
+        try {
+            jedis.strlen(key);
+            fail("Should throw JedisDataException for WRONGTYPE");
+        } catch (redis.clients.jedis.exceptions.JedisDataException e) {
+            assertTrue("Error message should contain WRONGTYPE",
+                e.getMessage().contains("WRONGTYPE"));
+        }
+    }
+
+    /**
+     * Test that GETDEL command returns WRONGTYPE error when executed on a non-String type key
+     */
+    @Test
+    public void testGetdelOnWrongType() {
+        String key = UUID.randomUUID().toString();
+        // First set a Hash type key
+        jedis.hset(key, "field1", "value1");
+        // Try to read with GETDEL command, should return WRONGTYPE error
+        try {
+            jedis.getDel(key);
+            fail("Should throw JedisDataException for WRONGTYPE");
+        } catch (redis.clients.jedis.exceptions.JedisDataException e) {
+            assertTrue("Error message should contain WRONGTYPE",
+                e.getMessage().contains("WRONGTYPE"));
+        }
+    }
 }

--- a/mocker-redis-spring-boot-starter/pom.xml
+++ b/mocker-redis-spring-boot-starter/pom.xml
@@ -41,7 +41,7 @@
 
     <groupId>com.github.microwww</groupId>
     <artifactId>mocker-redis-spring-boot-starter</artifactId>
-    <version>5.3.5-release</version>
+    <version>5.3.6-release</version>
 
     <properties>
         <java.version>1.8</java.version>
@@ -51,7 +51,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring-boot.version>2.2.9.RELEASE</spring-boot.version>
-        <redis-serve.version>0.3.5</redis-serve.version>
+        <redis-serve.version>0.3.6</redis-serve.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## PR Description

### Summary

This PR fixes two critical bugs in redis-mock:

1. **SCAN command MATCH filter not working** - The MATCH parameter in SCAN commands was being ignored
2. **Missing WRONGTYPE error** - Operations on keys with wrong data types returned incorrect results instead of proper Redis error

---

### Bug 1: SCAN MATCH Filter Not Working

#### Problem Description

The `SCAN` command with `MATCH` parameter was not filtering results correctly. For example:

```bash
# Set multiple keys with different prefixes
SET user:profile:001 value1
SET user:profile:002 value2
SET user:settings value3
SET product:item:001 value4

# SCAN with MATCH pattern - should only return keys matching the pattern
SCAN 0 MATCH user:profile:*
```

**Before fix:** All keys were returned regardless of the MATCH pattern.

**After fix:** Only keys matching `user:profile:*` are returned.

#### Root Cause

In [`ScanIterator.continueWrite()`](core/src/main/java/com/github/microwww/redis/protocal/ScanIterator.java:43), the MATCH pattern was parsed but never applied during iteration.

#### Solution

Modified the iteration logic to apply pattern matching using `Pattern.matcher().matches()` to filter keys.

---

### Bug 2: Missing WRONGTYPE Error

#### Problem Description

When performing operations on keys holding incorrect data types, Redis should return a `WRONGTYPE` error. For example:

```bash
SADD myset member1
GET myset
# Expected: (error) WRONGTYPE Operation against a key holding the wrong kind of value
```

#### Solution

1. **Added [`WrongTypeException`](core/src/main/java/com/github/microwww/redis/exception/WrongTypeException.java)** - A new exception class with the standard Redis error message
2. **Modified [`RedisDatabase.get()`](core/src/main/java/com/github/microwww/redis/database/RedisDatabase.java:48)** - Added type checking when retrieving values, throws WrongTypeException on type mismatch

---

### Changes

| File | Change Type | Description |
|------|-------------|-------------|
| `ScanIterator.java` | Modified | Fixed MATCH pattern filtering in SCAN commands |
| `RedisDatabase.java` | Modified | Added type checking with WrongTypeException |
| `WrongTypeException.java` | Added | New exception class for WRONGTYPE errors |
| `KeyOperationTest.java` | Modified | Added test for SCAN MATCH functionality |
| `StringOperationTest.java` | Modified | Added tests for WRONGTYPE error scenarios |

---

### Test Coverage

- `testScanWithMatch()` - Verifies SCAN MATCH pattern filtering works correctly
- Tests verify that only matching keys are returned and non-matching keys are excluded
